### PR TITLE
Update @apollo/client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@apollo/client": {
-      "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.17.tgz",
-      "integrity": "sha512-MDt2rwMX1GqodiVEKJqmDmAz8xr0qJmq5PdWeIt0yDaT4GOkKYWZiWkyfhfv3raTk8PyJvbsNG9q2CqmUrlGfg==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.5.tgz",
+      "integrity": "sha512-EiQstc8VjeqosS2h21bwY9fhL3MCRRmACtRrRh2KYpp9vkDyx5pUfMnN3swgiBVYw1twdXg9jHmyZa1gZlvlog==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",
         "@wry/context": "^0.6.0",
@@ -20,7 +20,7 @@
         "symbol-observable": "^4.0.0",
         "ts-invariant": "^0.9.0",
         "tslib": "^2.3.0",
-        "zen-observable-ts": "~1.1.0"
+        "zen-observable-ts": "^1.2.0"
       }
     },
     "@babel/code-frame": {
@@ -990,11 +990,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
       "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
       "dev": true
-    },
-    "@types/zen-observable": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
-      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
     },
     "@wry/context": {
       "version": "0.6.1",
@@ -5218,11 +5213,10 @@
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz",
+      "integrity": "sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==",
       "requires": {
-        "@types/zen-observable": "0.8.3",
         "zen-observable": "0.8.15"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-cms-content",
-  "version": "0.1.1-pre.40",
+  "version": "0.1.1-pre.41",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "mapconfig-schema:build": "sh scripts/mapconfig-schema-build.sh"
   },
   "dependencies": {
-    "@apollo/client": "^3.4.17",
+    "@apollo/client": "^3.5.5",
     "@contentful/rich-text-html-renderer": "^15.6.2",
     "@hankei6km/rehype-image-salt": "^0.1.1-pre.36",
     "@types/hast": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-cms-content",
-  "version": "0.1.1-pre.40",
+  "version": "0.1.1-pre.41",
   "description": "Mirror content of remote cms to local files for nuxt-content",
   "author": "hankei6km <hankei6km@gmail.com> (https://github.com/hankei6km)",
   "license": "MIT",

--- a/src/lib/clients/contentful.ts
+++ b/src/lib/clients/contentful.ts
@@ -7,7 +7,14 @@ import {
   NodeRenderer
 } from '@contentful/rich-text-html-renderer'
 import fetch from 'cross-fetch'
-import { HttpLink } from '@apollo/client'
+// SyntaxError: Named export 'HttpLink' not found. The requested module '@apollo/client' is a CommonJS module, which may not support all module.exports as named exports.
+// CommonJS modules can always be imported via the default export, for example using:
+// import pkg from '@apollo/client';
+// const { HttpLink: HttpLink } = pkg;
+// なぜかこのエラーになるので対応.
+// types/gql.ts でも同じようなことになっている.
+import pkgApolloClient from '@apollo/client'
+const { HttpLink: HttpLink } = pkgApolloClient
 import {
   ClientBase,
   ClientChain,

--- a/src/types/gql.ts
+++ b/src/types/gql.ts
@@ -1,10 +1,21 @@
-import {
-  ApolloClient,
+// なぜかこのエラーになる.
+// このモジュールも @apollo/client も native ESM だと思うのだが、なぜ?
+//
+// SyntaxError: Named export 'gql' not found. The requested module '@apollo/client' is a CommonJS module, which may not support all module.exports as named exports.
+// CommonJS modules can always be imported via the default export, for example using:
+//
+// import pkg from '@apollo/client';
+// const { ApolloClient, InMemoryCache, gql } = pkg;
+//
+// 素直に上記の対応をやると ApolloClient の型(d.ts)の読み込みがうまくいかない。
+// ApolloClient は型と class が必要なので import と const で名前を変えて読み込む.
+import pkgApolloClient, {
+  ApolloClient as ApolloClientAsType,
   ApolloLink,
-  InMemoryCache,
-  gql,
   NormalizedCacheObject
 } from '@apollo/client'
+const { ApolloClient, InMemoryCache, gql } = pkgApolloClient
+
 import { apolloErrToMessages } from '../lib/util.js'
 import {
   ClientBase,
@@ -27,7 +38,7 @@ export function gqlClient() {
 }
 
 export abstract class ClientGqlBase extends ClientBase {
-  private _gqlClient!: ApolloClient<NormalizedCacheObject>
+  private _gqlClient!: ApolloClientAsType<NormalizedCacheObject>
   private _link!: ApolloLink
   constructor(link: ApolloLink, opts: ClientOpts) {
     // link が外部に露出しているのはどうなの?
@@ -82,3 +93,5 @@ export abstract class ClientGqlBase extends ClientBase {
     })
   }
 }
+
+export {}

--- a/test/lib/gql.spec.ts
+++ b/test/lib/gql.spec.ts
@@ -1,5 +1,8 @@
 import { jest } from '@jest/globals'
-import { ApolloLink, HttpLink } from '@apollo/client'
+// SyntaxError: The requested module '@apollo/client' does not provide an export named 'HttpLink'
+// types/gql.ts での対応と同じ.
+import pkgApolloClient, { ApolloLink as ApolloLinkAsType } from '@apollo/client'
+const { ApolloLink, HttpLink } = pkgApolloClient
 import { ClientKind, RawRecord } from '../../src/types/client.js' // type の export は import() で扱えない?(d.ts だから?)
 
 const { readQuery: _readQuery, ...utils } = await import(
@@ -19,7 +22,9 @@ const testLink = new ApolloLink((operation, forward) => {
   return forward(operation)
 })
 
-const mockFetchLink = (mockData: Record<string, any>): [any, ApolloLink] => {
+const mockFetchLink = (
+  mockData: Record<string, any>
+): [any, ApolloLinkAsType] => {
   // const mockFetch = jest.fn().mockResolvedValue({
   //   status: 200,
   //   text: jest.fn().mockResolvedValue(JSON.stringify(data) as never)


### PR DESCRIPTION
@apollo/client を 3.5.5 へアップデートしたら CJS で default export のみのように
扱おうとするようになる。
(vscode 上では EMS として扱っているように見える).

理由は不明。

とりあえずの対応。
