### PR TITLE
Add graphcms:gql client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-cms-content",
-  "version": "0.1.1-pre.41",
+  "version": "0.1.1-pre.42",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-cms-content",
-  "version": "0.1.1-pre.41",
+  "version": "0.1.1-pre.42",
   "description": "Mirror content of remote cms to local files for nuxt-content",
   "author": "hankei6km <hankei6km@gmail.com> (https://github.com/hankei6km)",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,7 @@ export const cli = async ({
         cliErr = await saveRemoteContent({
           client: await client(clientKind, {
             apiBaseURL,
+            apiName: saveOpts.apiName,
             credential: [...credential]
           }),
           mapConfig: await loadMapConfig(mapConfig),

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -13,6 +13,9 @@ export async function client(
   } else if (kind === 'contentful:gql') {
     const { ClientCtfGql } = await import('./clients/contentful.js')
     return new ClientCtfGql(opts)
+  } else if (kind === 'graphcms:gql') {
+    const { ClientGcmsGql } = await import('./clients/graphcms.js')
+    return new ClientGcmsGql(opts)
   } else if (kind === 'microcms') {
     const { ClientMicroCMS } = await import('./clients/microcms.js')
     return new ClientMicroCMS(opts)

--- a/src/lib/clients/graphcms.ts
+++ b/src/lib/clients/graphcms.ts
@@ -1,0 +1,32 @@
+import fetch from 'cross-fetch'
+// SyntaxError: Named export 'HttpLink' not found. The requested module '@apollo/client' is a CommonJS module, which may not support all module.exports as named exports.
+// CommonJS modules can always be imported via the default export, for example using:
+// import pkg from '@apollo/client';
+// const { HttpLink: HttpLink } = pkg;
+// なぜかこのエラーになるので対応.
+// types/gql.ts でも同じようなことになっている.
+import pkgApolloClient from '@apollo/client'
+const { HttpLink: HttpLink } = pkgApolloClient
+import { ClientKind, ClientOpts } from '../../types/client.js'
+import { ClientGqlBase } from '../../types/gql.js'
+
+export class ClientGcmsGql extends ClientGqlBase {
+  constructor(opts: ClientOpts) {
+    if (!opts.apiName) {
+      throw new Error(
+        'graphcms:gql constructor: environment(apiName) is not specified'
+      )
+    }
+    const link = new HttpLink({
+      uri: `${opts.apiBaseURL}${opts.credential[0]}/${opts.apiName}`,
+      fetch,
+      headers: {
+        Authorization: `Bearer ${opts.credential[1]}`
+      }
+    })
+    super(link, opts)
+  }
+  kind(): ClientKind {
+    return 'graphcms:gql'
+  }
+}

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -75,14 +75,19 @@ export function apolloErrToMessages(err: any): string {
     return [
       err.message,
       ...Object.entries(err)
-        .filter(
-          ([_k, v]: [string, any]) => v && Array.isArray(v.result?.errors)
-        )
-        .map(([k, v]: [string, any]) =>
-          v.result.errors
-            .map(({ message }: any) => `${k}: ${message}`)
-            .join('\n')
-        )
+        .map(([k, v]: [string, any]) => {
+          if (v) {
+            if (Array.isArray(v.result?.errors)) {
+              return v.result.errors
+                .map(({ message }: any) => `${k}: ${message}`)
+                .join('\n')
+            } else if (v.bodyText) {
+              return `${k}: ${v.statusCode} ${v.bodyText}`
+            }
+          }
+          return ''
+        })
+        .filter((v) => v !== '')
     ].join('\n')
   }
   return err

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -6,6 +6,7 @@ export const ClientKindValues = [
   'appsheet',
   'contentful',
   'contentful:gql',
+  'graphcms:gql',
   'microcms'
 ] as const
 export type ClientKind = typeof ClientKindValues[number]

--- a/test/lib/client.spec.ts
+++ b/test/lib/client.spec.ts
@@ -207,6 +207,14 @@ describe('client', () => {
     })
     expect(c.kind()).toEqual('contentful:gql')
   })
+  it('should return graphcms:gql client instanse', async () => {
+    const c = await client('graphcms:gql', {
+      apiBaseURL: 'https://[region].graphcms.com/v2/',
+      credential: ['projectId', 'pat'],
+      apiName: 'master'
+    })
+    expect(c.kind()).toEqual('graphcms:gql')
+  })
   it('should return microcms client instanse', async () => {
     const c = await client('microcms', {
       apiBaseURL: 'http://localhost:3000',

--- a/test/lib/clients/graphcms.spec.ts
+++ b/test/lib/clients/graphcms.spec.ts
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals'
+
+jest.unstable_mockModule('@apollo/client', async () => {
+  const mockHttpLink = jest.fn()
+  const reset = () => {
+    mockHttpLink.mockReset()
+  }
+  reset()
+  return {
+    default: {
+      // なぜか CJS  で import される症状の暫定対応.
+      HttpLink: mockHttpLink
+    },
+    _reset: reset,
+    _getMocks: () => ({
+      mockHttpLink
+    })
+  }
+})
+
+const mockApolloClient = await import('@apollo/client')
+const { mockHttpLink } = (mockApolloClient as any)._getMocks()
+const { ClientGcmsGql } = await import('../../../src/lib/clients/graphcms.js')
+
+afterEach(async () => {
+  ;(mockApolloClient as any)._reset()
+})
+
+describe('client_grapghcms:gql', () => {
+  it('should setup HttpLink', async () => {
+    new ClientGcmsGql({
+      apiBaseURL: 'https://[region].graphcms.com/v2/',
+      credential: ['projectId', 'pat'],
+      apiName: 'master'
+    })
+    const p = mockHttpLink.mock.calls[0][0]
+    expect(p.uri).toEqual('https://[region].graphcms.com/v2/projectId/master')
+    expect(p.headers).toEqual({ Authorization: 'Bearer pat' })
+  })
+  it('should throw error when environment(apiName) is blank', async () => {
+    expect(
+      () =>
+        new ClientGcmsGql({
+          apiBaseURL: 'https://[region].graphcms.com/v2/',
+          credential: ['projectId', 'pat'],
+          apiName: ''
+        })
+    ).toThrowError(/environment/)
+  })
+})
+
+export {}

--- a/test/lib/util.spec.ts
+++ b/test/lib/util.spec.ts
@@ -152,6 +152,22 @@ describe('apolloErrToMessages', () => {
       'Response not successful: Received status code 400\nnetworkError: Query cannot be executed. The maximum allowed complexity for a query is 11000 but it was 50100. Simplify the query e.g. by setting lower limits for collections.'
     )
   })
+  it('should return message from apollo errors(bodyText)', () => {
+    const mockErr = {
+      graphQLErrors: [],
+      clientErrors: [],
+      networkError: {
+        name: 'ServerParseError',
+        response: { size: 0, timeout: 0 },
+        statusCode: 404,
+        bodyText: 'Page not found.'
+      },
+      message: 'Unexpected token P in JSON at position 0'
+    }
+    expect(apolloErrToMessages(mockErr)).toEqual(
+      'Unexpected token P in JSON at position 0\nnetworkError: 404 Page not found.'
+    )
+  })
   it('should return message from apollo errors(multiple kind)', () => {
     const mockErr = {
       graphQLErrors: {


### PR DESCRIPTION
- Support "bodyText" in apolloErrToMessages
- Add graphcms:gql client
