### PR TITLE
Use "vars" as query parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-cms-content",
-  "version": "0.1.1-pre.56",
+  "version": "0.1.1-pre.57",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-cms-content",
-  "version": "0.1.1-pre.56",
+  "version": "0.1.1-pre.57",
   "description": "Mirror content of remote cms to local files for nuxt-content",
   "author": "hankei6km <hankei6km@gmail.com> (https://github.com/hankei6km)",
   "license": "MIT",

--- a/src/lib/clients/microcms.ts
+++ b/src/lib/clients/microcms.ts
@@ -35,10 +35,25 @@ export class ClientMicroCMS extends ClientBase {
     return 'microcms'
   }
   protected _fldsBaseName: string[] = ['id', 'createdAt', 'updatedAt']
-  async _fetch({ skip, pageSize, flds }: FetchParams): Promise<FetchResult> {
+  protected varsWhite: Set<string> = new Set([
+    // クエリーパラメーターとして許可する一覧.
+    'orders',
+    'q',
+    'ids',
+    'filters',
+    'depth'
+  ])
+  async _fetch({
+    skip,
+    pageSize,
+    flds,
+    vars
+  }: FetchParams): Promise<FetchResult> {
     const headers: AxiosRequestConfig['headers'] = {}
     headers[this._opts.credential[0]] = this._opts.credential[1]
-    const params: Record<string, any> = {}
+    const params: Record<string, any> = {
+      ...this.safeVars(vars)
+    }
     const filterString = queryFilters(this._filter)
     if (filterString) {
       params['filters'] = filterString

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'fs'
 import toNumber from 'lodash.tonumber'
-import { GqlVars } from '../types/gql.js'
-import { OpValue } from '../types/client.js'
+import { OpValue, QuerylVars } from '../types/client.js'
 
 export function decodeFilter(filter: string[]): OpValue[] {
   return filter
@@ -34,10 +33,10 @@ export function readQuery(
   }
 }
 
-export function decodeVars(vars: string[], forceString?: boolean): GqlVars {
-  const ret: GqlVars = {}
+export function decodeVars(vars: string[], forceString?: boolean): QuerylVars {
+  const ret: QuerylVars = {}
   vars
-    .map<[keyof GqlVars, GqlVars[keyof GqlVars]]>((v) => {
+    .map<[keyof QuerylVars, QuerylVars[keyof QuerylVars]]>((v) => {
       const kv = v.split('=')
       const len = kv.length
       if (len === 1 && !forceString) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,7 @@ import { ClientKindValues } from './types/client.js'
               type: 'string',
               array: true,
               required: false,
-              description: 'variables to GraphQL',
+              description: 'variables to GraphQL or REST query params',
               coerce: yargsArrayFromEnvVars
             },
             'vars-str': {

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,6 +1,5 @@
 import { printInfo } from '../lib/log.js'
 import { readQuery, decodeVars } from '../lib/util.js'
-import { GqlVars } from './gql.js'
 import { MapFld } from './map.js'
 
 export const ClientKindValues = [
@@ -92,6 +91,13 @@ export class ResRecord {
   }
 }
 
+// command の flag で渡された variables を収めておくオブジェクト.
+// いまのところはスカラーぽいものだけ.
+// REST とGraphQL で共有.
+// - REST - クエリーパラメーターとして利用
+// - GraphQL - Variables として利用
+export type QuerylVars = Record<string, boolean | number | string>
+
 export type FetchParams = {
   skip: number
   pageSize?: number
@@ -162,7 +168,7 @@ export abstract class ClientBase {
   ]
   protected _flds: Set<string> = new Set<string>()
   protected _query: string[] = []
-  protected _vars: GqlVars = {}
+  protected _vars: QuerylVars = {}
   protected _transformer: TransformContent | undefined = undefined
 
   protected _setupErr: Error | undefined

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -233,6 +233,16 @@ export abstract class ClientBase {
     this._transformer = t
     return this
   }
+  protected varsWhite: Set<string> = new Set(['']) // 基本は許可しない. abstract の方が良いか？
+  protected safeVars(v: QuerylVars): QuerylVars {
+    const ret: QuerylVars = {}
+    Object.entries(v)
+      .filter(([k]) => this.varsWhite.has(k))
+      .forEach(([k, v]) => {
+        ret[k] = v
+      })
+    return ret
+  }
   protected resRecord(r: RawRecord): ResRecord {
     return new ResRecord(r)
   }

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -104,6 +104,7 @@ export type FetchParams = {
   flds?: string[]
   endCursor?: string | null
   query: string[]
+  vars: QuerylVars
 }
 
 export type FetchResultNextTotal = {
@@ -248,6 +249,7 @@ export abstract class ClientBase {
     let limit = this._limit
     const flds = Array.from(this._flds)
     const query = this._query
+    const vars = this._vars
     let count = 0
     let endCursor: string | undefined | null = null
 
@@ -282,7 +284,7 @@ export abstract class ClientBase {
         }${pageSize !== undefined ? `, pageSize=${pageSize}` : ''}`
       )
 
-      res = await this._fetch({ skip, pageSize, flds, endCursor, query })
+      res = await this._fetch({ skip, pageSize, flds, endCursor, query, vars })
 
       printInfo(`ClientBase.fetch:   count=${res.fetch.count}`)
 

--- a/src/types/gql.ts
+++ b/src/types/gql.ts
@@ -29,10 +29,6 @@ import {
 } from '../types/client.js'
 //ApolloProvider,
 
-// command の flag で渡された variables を収めておくオブジェクト.
-// いまのところはスカラーぽいものだけ.
-export type GqlVars = Record<string, boolean | number | string>
-
 export function gqlClient() {
   return new ApolloClient({
     cache: new InMemoryCache()

--- a/src/types/gql.ts
+++ b/src/types/gql.ts
@@ -106,7 +106,8 @@ export abstract class ClientGqlBase extends ClientBase {
     skip,
     pageSize,
     endCursor,
-    query
+    query,
+    vars
   }: FetchParams): Promise<FetchResult> {
     return new Promise((resolve, reject) => {
       this._gqlClient
@@ -116,7 +117,7 @@ export abstract class ClientGqlBase extends ClientBase {
             skip,
             pageSize,
             endCursor,
-            ...this._vars
+            ...vars
           }
         })
         .then((res) => {

--- a/test/lib/client.spec.ts
+++ b/test/lib/client.spec.ts
@@ -169,7 +169,8 @@ describe('ClientBase', () => {
       pageSize: undefined,
       flds: [],
       endCursor: null,
-      query: []
+      query: [],
+      vars: {}
     })
     expect(await g.next()).toEqual({
       value: undefined,
@@ -192,7 +193,8 @@ describe('ClientBase', () => {
       pageSize: 30,
       flds: [],
       endCursor: null,
-      query: []
+      query: [],
+      vars: {}
     })
     expect(await g.next()).toEqual({
       value: {
@@ -206,7 +208,8 @@ describe('ClientBase', () => {
       pageSize: 30,
       flds: [],
       endCursor: null,
-      query: []
+      query: [],
+      vars: {}
     })
     expect(await g.next()).toEqual({
       value: {
@@ -220,7 +223,8 @@ describe('ClientBase', () => {
       pageSize: 30,
       flds: [],
       endCursor: null,
-      query: []
+      query: [],
+      vars: {}
     })
     expect(await g.next()).toEqual({
       value: {
@@ -234,7 +238,8 @@ describe('ClientBase', () => {
       pageSize: 30,
       flds: [],
       endCursor: null,
-      query: []
+      query: [],
+      vars: {}
     }) // limit を指定していない.
     expect(await g.next()).toEqual({
       value: undefined,
@@ -257,7 +262,8 @@ describe('ClientBase', () => {
       pageSize: undefined,
       flds: [],
       endCursor: null,
-      query: []
+      query: [],
+      vars: {}
     })
     expect(c._fetch).toHaveBeenCalledTimes(1)
   })
@@ -276,7 +282,8 @@ describe('ClientBase', () => {
       pageSize: 30,
       flds: [],
       endCursor: null,
-      query: []
+      query: [],
+      vars: {}
     })
     expect(await g.next()).toEqual({
       value: {
@@ -290,7 +297,8 @@ describe('ClientBase', () => {
       pageSize: 30,
       flds: [],
       endCursor: null,
-      query: []
+      query: [],
+      vars: {}
     })
     expect(await g.next()).toEqual({
       value: {
@@ -304,7 +312,8 @@ describe('ClientBase', () => {
       pageSize: 15,
       flds: [],
       endCursor: null,
-      query: []
+      query: [],
+      vars: {}
     })
     expect(await g.next()).toEqual({
       value: undefined,
@@ -330,7 +339,21 @@ describe('ClientBase', () => {
       pageSize: undefined,
       flds: ['_RowNumber', 'id', 'createdAt', 'updatedAt', 'test'],
       endCursor: null,
-      query: []
+      query: [],
+      vars: {}
+    })
+  })
+  it('should pass vars', async () => {
+    const c = new ClientTest({ apiBaseURL: '', credential: [] }).genRecord(100)
+    const g = c.vars(['var1=abc', 'var2=123']).fetch()
+    await g.next()
+    expect(c._fetch).toHaveBeenLastCalledWith({
+      skip: 0,
+      pageSize: undefined,
+      flds: [],
+      endCursor: null,
+      query: [],
+      vars: { var1: 'abc', var2: 123 }
     })
   })
   it('should print info from fetch method', async () => {

--- a/test/lib/clients/microcms.spec.ts
+++ b/test/lib/clients/microcms.spec.ts
@@ -226,6 +226,56 @@ describe('client_appsheet', () => {
     await next
     // fields の実際のレスポンスは検証できないので省略.
   })
+  it('should get bare content from microCMS app with query vars', async () => {
+    const n = new Date().toUTCString()
+
+    const c = new ClientMicroCMS({
+      apiBaseURL: 'http://localhost:3000/test-nuxt-0x.microcms.io/api/v1/',
+      apiName: 'tbl',
+      credential: ['X-API-KEY', 'secret']
+    })
+      .request()
+      .vars([
+        'orders=-updatedAt',
+        'filters=createdAt[greater_than]2021-11',
+        'offset=100' // offset は許可されていない.
+      ])
+    const g = c.fetch()
+    const next = g.next()
+    expect(mockAxios.get).toHaveBeenLastCalledWith(
+      'http://localhost:3000/test-nuxt-0x.microcms.io/api/v1/tbl',
+      {
+        headers: { 'X-API-KEY': 'secret' },
+        params: {
+          orders: '-updatedAt',
+          filters: 'createdAt[greater_than]2021-11'
+          // offset は許可されていない.
+        }
+      }
+    )
+    const mockData = {
+      contents: [
+        {
+          id: 'idstring1',
+          createdAt: n,
+          updatedAt: n,
+          title: 'title1'
+        },
+        {
+          id: 'idstring2',
+          createdAt: n,
+          updatedAt: n,
+          title: 'title1'
+        }
+      ],
+      totalCount: 2
+    }
+    mockAxios.mockResponse({
+      data: mockData
+    })
+    await next
+    // query の実際のレスポンスは検証できないので省略.
+  })
 })
 
 export {}

--- a/test/lib/content.spec.ts
+++ b/test/lib/content.spec.ts
@@ -637,7 +637,8 @@ describe('saveRemoteContent()', () => {
         'description'
       ],
       endCursor: null,
-      query: []
+      query: [],
+      vars: {}
     })
   })
   it('should get remote content and save as local files with transform content', async () => {


### PR DESCRIPTION
- Add QuerylVars instead of GqlVars
- Pass "vars" to "_fetch()" method
- Use "vars" to build query parameters in microCMS client
